### PR TITLE
Fix ci allclose error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         os:
           - ubuntu-latest
         #   - windows-latest
-        #   - macOS-latest
+          - macOS-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/seqal/base_scorer.py
+++ b/seqal/base_scorer.py
@@ -124,8 +124,8 @@ class BaseScorer:
         if not torch.is_tensor(mat1) or not torch.is_tensor(mat2):
             raise TypeError("Input type is not torch.Tensor")
 
-        mat1 = mat1.float()
-        mat2 = mat2.float()
+        mat1 = mat1.double()
+        mat2 = mat2.double()
 
         mat1_n, mat2_n = mat1.norm(dim=1)[:, None], mat2.norm(dim=1)[:, None]
         mat1_norm = mat1 / torch.max(mat1_n, eps * torch.ones_like(mat1_n))

--- a/seqal/base_scorer.py
+++ b/seqal/base_scorer.py
@@ -127,10 +127,14 @@ class BaseScorer:
         mat1 = mat1.double()
         mat2 = mat2.double()
 
-        mat1_n, mat2_n = mat1.norm(dim=1)[:, None], mat2.norm(dim=1)[:, None]
-        mat1_norm = mat1 / torch.max(mat1_n, eps * torch.ones_like(mat1_n))
-        mat2_norm = mat2 / torch.max(mat2_n, eps * torch.ones_like(mat2_n))
-        sim_mt = torch.mm(mat1_norm, mat2_norm.transpose(0, 1))
+        numerator = torch.mm(mat1, mat2.transpose(0, 1))
+        mat1_n, mat2_n = (
+            torch.linalg.norm(mat1, dim=1, keepdims=True),
+            torch.linalg.norm(mat2, dim=1, keepdims=True),
+        )
+        norm_mul = torch.mm(mat1_n, mat2_n.transpose(0, 1))
+        denominator = torch.max(norm_mul, torch.full_like(norm_mul, eps))
+        sim_mt = numerator / denominator
 
         return sim_mt
 

--- a/seqal/scorers.py
+++ b/seqal/scorers.py
@@ -322,7 +322,9 @@ class DistributeSimilarityScorer(BaseScorer):
         for label, label_entities in entities_per_label.items():
             vectors = torch.stack([entity.vector for entity in label_entities])
             similarities = self.similarity_matrix(vectors, vectors)
-            similarity_matrix_per_label[label] = np.array(similarities)
+            similarity_matrix_per_label[label] = (
+                similarities.cpu().detach().numpy().copy()
+            )
         return similarity_matrix_per_label
 
 

--- a/tests/test_base_scorer.py
+++ b/tests/test_base_scorer.py
@@ -16,10 +16,10 @@ def base_scorer(scope="function"):
 @pytest.fixture()
 def matrix_multiple_var(scope="function"):
     """Embedding matrix for test"""
-    mat1 = torch.tensor([[3, 4], [3, 4]], dtype=torch.float32)
-    mat2 = torch.tensor([[7, 24], [7, 24], [7, 24]], dtype=torch.float32)
+    mat1 = torch.tensor([[3, 4], [3, 4]], dtype=torch.float64)
+    mat2 = torch.tensor([[7, 24], [7, 24], [7, 24]], dtype=torch.float64)
     expected = torch.tensor(
-        [[0.9360, 0.9360, 0.9360], [0.9360, 0.9360, 0.9360]], dtype=torch.float32
+        [[0.9360, 0.9360, 0.9360], [0.9360, 0.9360, 0.9360]], dtype=torch.float64
     )
 
     return {"mat1": mat1, "mat2": mat2, "expected": expected}

--- a/tests/test_base_scorer.py
+++ b/tests/test_base_scorer.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import torch
+from torch.nn.functional import cosine_similarity
 
 from seqal.base_scorer import BaseScorer
 from seqal.datasets import Corpus
@@ -179,6 +180,27 @@ class TestBaseScorer:
 
         # Assert
         assert torch.equal(sim_mt, matrix_multiple_var["expected"]) is True
+
+    def test_similarity_matrix_comparing_with_cosine_similarity(
+        self, base_scorer: BaseScorer
+    ) -> None:
+        """Test similarity_matrix function return correct result"""
+        # Arrange
+        v0 = torch.tensor([-0.1, 0.1], dtype=torch.float64)
+        v1 = torch.tensor([0.1, 0.1], dtype=torch.float64)
+        v2 = torch.tensor([0.1, -0.1], dtype=torch.float64)
+        vectors = torch.stack([v0, v1, v2])
+        excepted0 = cosine_similarity(torch.stack([v0]), vectors)
+        excepted1 = cosine_similarity(torch.stack([v1]), vectors)
+        excepted2 = cosine_similarity(torch.stack([v2]), vectors)
+
+        # Act
+        sim_mt = base_scorer.similarity_matrix(vectors, vectors)
+
+        # Assert
+        assert torch.allclose(sim_mt[0], excepted0) is True
+        assert torch.allclose(sim_mt[1], excepted1) is True
+        assert torch.allclose(sim_mt[2], excepted2) is True
 
     def test_similarity_matrix_raise_error_if_input_type_is_not_tensor(
         self, base_scorer: BaseScorer, matrix_multiple_var: dict

--- a/tests/test_base_scorer.py
+++ b/tests/test_base_scorer.py
@@ -180,20 +180,6 @@ class TestBaseScorer:
         # Assert
         assert torch.equal(sim_mt, matrix_multiple_var["expected"]) is True
 
-    def test_similarity_matrix_if_tensor_dtype_is_not_float32(
-        self, base_scorer: BaseScorer, matrix_multiple_var: dict
-    ) -> None:
-        """Test similarity_matrix function return correct result if input data type is not tensor.float32"""
-        # Arrange
-        mat1 = matrix_multiple_var["mat1"].to(dtype=torch.int32)
-        mat2 = matrix_multiple_var["mat2"].to(dtype=torch.float64)
-
-        # Act
-        sim_mt = base_scorer.similarity_matrix(mat1, mat2)
-
-        # Assert
-        assert torch.equal(sim_mt, matrix_multiple_var["expected"]) is True
-
     def test_similarity_matrix_raise_error_if_input_type_is_not_tensor(
         self, base_scorer: BaseScorer, matrix_multiple_var: dict
     ) -> None:

--- a/tests/test_scorers.py
+++ b/tests/test_scorers.py
@@ -153,7 +153,9 @@ def compare_approximate(dict1, dict2):
     """Return whether two dicts of arrays are roughly equal"""
     if dict1.keys() != dict2.keys():
         return False
-    return all(np.allclose(dict1[key], dict2[key], rtol=1e-05, atol=1e-08) for key in dict1)
+    return all(
+        np.allclose(dict1[key], dict2[key], rtol=1e-05, atol=1e-08) for key in dict1
+    )
 
 
 class TestRandomScorer:

--- a/tests/test_scorers.py
+++ b/tests/test_scorers.py
@@ -153,7 +153,7 @@ def compare_approximate(dict1, dict2):
     """Return whether two dicts of arrays are roughly equal"""
     if dict1.keys() != dict2.keys():
         return False
-    return all(np.allclose(dict1[key], dict2[key], rtol=1e-3) for key in dict1)
+    return all(np.allclose(dict1[key], dict2[key], rtol=1e-05, atol=1e-08) for key in dict1)
 
 
 class TestRandomScorer:


### PR DESCRIPTION
ローカルで`test_similarity_matrix_per_label()`はエラーがなかったが、CIでエラーが発生した。

```
>       assert compare_approximate(sentence_scores, similarity_matrix_per_label) is True
E       AssertionError: assert False is True
E        +  where False = compare_approximate({'LOC': array([[0.99999994]], dtype=float32), 'PER': array([[ 9.99999940e-01,  1.26880515e-08, -9.99999940e-01],\n     ...15e-08,  9.99999940e-01, -1.26880515e-08],\n       [-9.99999940e-01, -1.26880515e-08,  9.99999940e-01]], dtype=float32)}, {'LOC': array([[1.]]), 'PER': array([[ 1.,  0., -1.],\n       [ 0.,  1.,  0.],\n       [-1.,  0.,  1.]])})
```

`np.allclose(np.array([ 9.99999940e-01,  1.26880515e-08, -9.99999940e-01], dtype=float32), np.array([ 1.,  0., -1.]), rtol=0.001)`はFalseを返したから、エラーが発生した。しかし、ローカルでテストする時、1.26880515e-08は0になっている。このPRで原因を確認する。


---
検証の結果：

mac os で`test_similarity_matrix_per_label()`が通ったけど、linux osが通らなかった。問題の原因はここ：https://github.com/pytorch/pytorch/issues/20551 。normの計算は問題があって、float32の計算結果の誤差が大きい。

https://github.com/tech-sketch/SeqAL/pull/18 でいくつかの手法を試して、以下2つがテストを通った手法:
- similarity_matrix() のなか、torch.float32をtorch.float64に変更すると、誤差が少なく、CIのテストが通った
- torch.float32の場合、similarity_matrix()の中、torch.normの誤差が大きいので、customなmat1.square().sum(dim=-1, keepdim=True).sqrt()に変更する。後はcosine_similarityの計算と同じ、torch.maxは最後にやる。以下のようにすると、誤差が少なく、CIのテストが通れる
  - 更新: https://github.com/tech-sketch/SeqAL/runs/5388711442?check_suite_focus=true consine_similarityの比較結果はまだエラーが出た。torch.float64の修正案にする