### PR TITLE
Fix install dependencies error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        poetry-version: ["1.2.0"]
         linter:
           - name: Flake8
             run: flake8
@@ -27,6 +28,8 @@ jobs:
         with:
           python-version: 3.8
       - uses: abatilo/actions-poetry@v2.1.0
+        with:
+          poetry-version: ${{ matrix.poetry-version }}
       - name: Install Dependencies
         run: poetry install
       - name: ${{ matrix.linter.name }}
@@ -47,15 +50,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        #   - 3.6
-        #   - 3.7
-          - 3.8
-        #   - 3.9
-        os:
-          - ubuntu-latest
-        #   - windows-latest
-          - macOS-latest
+        python-version: ["3.8", "3.9"]
+        poetry-version: ["1.2.0"]
+        os: [ubuntu-18.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -64,6 +61,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: abatilo/actions-poetry@v2.1.0
+        with:
+          poetry-version: ${{ matrix.poetry-version }}
       - name: Install Dependencies
         run: poetry install
       - name: Test with Pytest


### PR DESCRIPTION
CIはinstall dependenciesの段階でエラー


```
Run poetry install
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.13/x64/bin/poetry", line 5, in <module>
    from poetry.console import main
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/__init__.py", line 1, in <module>
    from .application import Application
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/application.py", line 7, in <module>
    from .commands.about import AboutCommand
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/commands/__init__.py", line 2, in <module>
    from .add import AddCommand
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/commands/add.py", line 8, in <module>
    from .init import InitCommand
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/commands/init.py", line 16, in <module>
    from poetry.core.pyproject import PyProjectException
ImportError: cannot import name 'PyProjectException' from 'poetry.core.pyproject' (/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/core/pyproject/__init__.py)
Error: Process completed with exit code 1.
```

Solution:
- update ci setup with poetry v1.2.0